### PR TITLE
Use `'static` notation

### DIFF
--- a/src/first_order.rs
+++ b/src/first_order.rs
@@ -230,20 +230,14 @@ enum Ctx {
 struct CtxFun<TRepr>(Box<dyn Fn(&Ctx) -> TRepr>);
 
 impl<TRepr> CtxFun<TRepr> {
-    fn new<F>(f: F) -> Self
-    where
-        for<'a> F: Fn(&Ctx) -> TRepr + 'a,
-    {
+    fn new(f: impl Fn(&Ctx) -> TRepr + 'static) -> Self {
         CtxFun(Box::new(f))
     }
 }
 
 // PhantomData here to get around "unconstrained type parameter T" in trait impl.
 struct PushNeg<T>(PhantomData<T>);
-impl<T: ExprSym> ExprSym for PushNeg<T>
-where
-    for<'a> T: 'a,
-{
+impl<T: ExprSym + 'static> ExprSym for PushNeg<T> {
     type Repr = CtxFun<T::Repr>;
 
     fn lit(i: i32) -> Self::Repr {
@@ -275,20 +269,14 @@ fn exprsym_push_neg0<S: ExprSym>(e: &CtxFun<S::Repr>) -> S::Repr {
 struct CtxFunPh<TRepr, T>(Box<dyn Fn(&Ctx) -> TRepr>, PhantomData<T>);
 
 impl<TRepr, T> CtxFunPh<TRepr, T> {
-    fn new<F>(f: F) -> Self
-    where
-        for<'a> F: Fn(&Ctx) -> TRepr + 'a,
-    {
+    fn new(f: impl Fn(&Ctx) -> TRepr + 'static) -> Self {
         CtxFunPh(Box::new(f), PhantomData)
     }
 }
 
 // PhantomData here to get around "unconstrained type parameter T" in trait impl.
 struct PushNegPh<T>(PhantomData<T>);
-impl<T: ExprSym> ExprSym for PushNegPh<T>
-where
-    for<'a> T: 'a,
-{
+impl<T: ExprSym + 'static> ExprSym for PushNegPh<T> {
     type Repr = CtxFunPh<T::Repr, T>;
 
     fn lit(i: i32) -> Self::Repr {
@@ -312,10 +300,7 @@ where
 
 // Here I'd love to write just CtxFun<T::Repr>, but then the compiler complains
 // T is not constrained. So we pass on the T into CtxFun as phantomdata.
-impl<T: ExprSym> HasExprSym for CtxFunPh<T::Repr, T>
-where
-    for<'a> T: 'a,
-{
+impl<T: ExprSym + 'static> HasExprSym for CtxFunPh<T::Repr, T> {
     type ES = PushNegPh<T>;
 }
 

--- a/src/higher_order.rs
+++ b/src/higher_order.rs
@@ -105,9 +105,7 @@ trait ExprSym {
 
     fn int(i: i32) -> Self::Repr<i32>;
     fn add(a: &Self::Repr<i32>, b: &Self::Repr<i32>) -> Self::Repr<i32>;
-    fn lam<A, B, F: Fn(Self::Repr<A>) -> Self::Repr<B>>(f: F) -> Self::Repr<Fun<A, B>>
-    where
-        for<'a> F: 'a;
+    fn lam<A, B>(f: impl Fn(Self::Repr<A>) -> Self::Repr<B> + 'static) -> Self::Repr<Fun<A, B>>;
     fn app<F: Fn(A) -> B, A, B>(f: Self::Repr<F>, arg: Self::Repr<A>) -> Self::Repr<B>;
 }
 
@@ -125,10 +123,9 @@ impl ExprSym for Eval {
         a + b
     }
 
-    fn lam<A, B, F: Fn(Self::Repr<A>) -> Self::Repr<B>>(f: F) -> Self::Repr<Box<dyn Fn(A) -> B>>
-    where
-        for<'a> F: 'a,
-    {
+    fn lam<A, B>(
+        f: impl Fn(Self::Repr<A>) -> Self::Repr<B> + 'static,
+    ) -> Self::Repr<Box<dyn Fn(A) -> B>> {
         Box::new(f)
     }
 
@@ -157,10 +154,7 @@ impl ExprSym for View {
         Rc::new(move |count| format!("({} + {})", a(count), b(count)))
     }
 
-    fn lam<A, B, F: Fn(Self::Repr<A>) -> Self::Repr<B>>(f: F) -> Self::Repr<Fun<A, B>>
-    where
-        for<'a> F: 'a,
-    {
+    fn lam<A, B>(f: impl Fn(Self::Repr<A>) -> Self::Repr<B> + 'static) -> Self::Repr<Fun<A, B>> {
         Rc::new(move |count| {
             format!(
                 "(\\x{} -> {})",


### PR DESCRIPTION
There's a shorthand for `for <'a> T: 'a`, it is `T: 'static`.

In many cases it allowed to not split the constraints between the `where` block and the list or generic arguments. Additionally, in some places it removed the need for a type to be named at all and allowed to use the `f: impl ...` notation.